### PR TITLE
Add store.getState

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ module.exports = function createStore (modifier, initialState) {
   var isEmitting = false
   var state = extend(initialState)
   store.initialState = getInitialState
+  store.getState = getState
   store.emit = store
   store.on = on
   return store
@@ -70,6 +71,16 @@ module.exports = function createStore (modifier, initialState) {
   */
   function getInitialState () {
     return initialState
+  }
+
+  /**
+   * Get the current state of the store
+   * @name store.getState
+   * @example
+   * var state = store.getState()
+   */
+  function getState () {
+    return state
   }
 
   /**


### PR DESCRIPTION
An action creator may end up getting called by a component that has access to only a very small slice of the current state.  `store.getState` would allow the action creator to get other state properties it may need to complete the action.

For instance:

`actions.js`:

``` js
function increment () {
  var state = app.store.getState()
  var count = state.items.count
  app.store({ type: 'items:increment', count: count++ })
}
```

`component.js`

``` js
function Component (props) {
  var counter = props.counter
  var increment = props.actions.increment
  return h('div', [
    counter,
    h('button, { onclick: increment }, 'Increment')
  ])
}
```
